### PR TITLE
Pass the Cookie header to all htpasswd-login requests

### DIFF
--- a/example/auth_request.inc.conf
+++ b/example/auth_request.inc.conf
@@ -23,7 +23,9 @@ location = /auth {
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_set_header X-Forwarded-Proto $scheme;
          proxy_set_header Authorization $http_authorization;
+         proxy_set_header Cookie $http_cookie;
          proxy_pass_header Authorization;
+         proxy_pass_header Cookie;
 }
 
 error_page 401 = @error401;
@@ -37,6 +39,8 @@ location = /_htpasswd_logout {
          proxy_set_header X-Real-IP $remote_addr;
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_set_header X-Forwarded-Proto $scheme;
+         proxy_set_header Cookie $http_cookie;
+         proxy_pass_header Cookie;
 }
 
 location /_htpasswd_login/ {
@@ -45,4 +49,6 @@ location /_htpasswd_login/ {
          proxy_set_header X-Real-IP $remote_addr;
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_set_header X-Forwarded-Proto $scheme;
+         proxy_set_header Cookie $http_cookie;
+         proxy_pass_header Cookie;
 }


### PR DESCRIPTION
This should prevent #5:

Some nginx configurations may exclude that header from being passed, and we urgently need it; so add it to the proxy_pass_header list and explicitly set it from the request.

@112madgamer, can you confirm that this is just about the config change you ended up making? (And sorry for taking so long to actually action this!)